### PR TITLE
Update Catppuccin macchiato.json

### DIFF
--- a/Vendetta/macchiato/Catppuccin macchiato.json
+++ b/Vendetta/macchiato/Catppuccin macchiato.json
@@ -1,5 +1,5 @@
 {
-    "name": "Catppuccin macchiato",
+    "name": "Catppuccin macchiato(beta)",
     "description": "😸 Soothing pastel theme for the high-spirited!",
     "authors": [
       {
@@ -9,7 +9,7 @@
     ],
     "semanticColors": {
       "BACKGROUND_ACCENT": [
-      "#8aadf4"
+      "#eed49f"
       ],
       "BACKGROUND_FLOATING": [
       "#1e2030"
@@ -69,6 +69,9 @@
       "#a6da95"
       ],
       "CHANNELS_DEFAULT": [
+      "#72778F"
+      ],
+      "CHANNEL_TEXT_AREA_PLACEHOLDER" : [
       "#939ab7"
       ],
       "CHAT_BACKGROUND": [
@@ -90,7 +93,7 @@
       "#939ab7"
       ],
       "INTERACTIVE_MUTED": [
-      "#5b6078"
+      "#939ab7"
       ],
       "INTERACTIVE_NORMAL": [
       "#939ab7"
@@ -138,6 +141,7 @@
       "PRIMARY_300": "#24273a",
       "PRIMARY_360": "#c6a0f6",
       "PRIMARY_400": "#c6a0f6",
+      "PRIMARY_460": "#1e2030",
       "PRIMARY_500": "#cad3f5",
       "PRIMARY_600": "#24273a",
       "PRIMARY_630": "#24273a",


### PR DESCRIPTION
# Fixed Add status and edit profile bg color in tabsv2.
![IMG_20230706_184630](https://github.com/Quinxxxx/Discord/assets/137756384/2cda9a41-2ea4-4db1-bc45-3a683cf99a35)
# Matched color of elements and text of bottom chat box.
![IMG_20230706_152638](https://github.com/Quinxxxx/Discord/assets/137756384/ff624752-1d5c-4308-9aac-3686091b4807)
# Lastly, added back the og branch color and dialed down brightness of text for normal channels, which don't have new messages.
![IMG_20230706_184746](https://github.com/Quinxxxx/Discord/assets/137756384/214f30b7-5e0f-498e-8734-c92e207d68a8)
